### PR TITLE
make composer install work on windows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,13 +38,13 @@
             "rm public/.gitignore translations/.gitignore"
         ],
         "post-install-cmd": [
-            "bin/console bolt:copy-themes",
+            "php bin/console bolt:copy-themes",
             "@auto-scripts",
-            "bin/console bolt:info"
+            "php bin/console bolt:info"
         ],
         "post-update-cmd": [
             "@auto-scripts",
-            "bin/console bolt:info"
+            "php bin/console bolt:info"
         ]
     },
     "conflict": {


### PR DESCRIPTION
I'm getting errors when creating the project or running composer install because of post install scripts.
"'bin' is not recognized as an internal or external command," 
adding php before the commands fixes that